### PR TITLE
var missing for subnet

### DIFF
--- a/terraform/variables.tf.CHANGEME
+++ b/terraform/variables.tf.CHANGEME
@@ -50,6 +50,12 @@ variable "application-server-subnet-ip-address-range" {
 	default = "10.0.1.0/28"
 }
 
+#added block
+variable "cloud-run-service-subnet-ip-address-range" {
+  type    = string
+  default = "10.0.7.0/24"
+}
+
 variable "http-port" {
 	type = string
 	default = "80"


### PR DESCRIPTION
Terraform is unable to find a declaration for the variable cloud-run-service-subnet-ip-address-range, which is referenced in cloud-run-service-subnet.tf file. To resolve this error, need to declare this variable in your Terraform configuration.

Here's how you can declare the missing variable:

```
variable "cloud-run-service-subnet-ip-address-range" {
  type    = string
  default = "10.0.1.0/24" 
}
```